### PR TITLE
Implement webserver listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,12 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -126,11 +132,42 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
 ]
 
 [[package]]
@@ -138,6 +175,12 @@ name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -196,6 +239,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -267,9 +319,18 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -278,7 +339,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -314,11 +375,19 @@ dependencies = [
  "rcon",
  "regex",
  "serde",
+ "serde_json",
  "serenity",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "warp",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "encoding_rs"
@@ -342,6 +411,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "filetime"
@@ -401,6 +476,12 @@ checksum = "77a29c77f1ca394c3e73a9a5d24cfcabb734682d9634fc398f2204a63c994120"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -516,6 +597,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -560,6 +650,31 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "headers"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
+dependencies = [
+ "base64 0.12.3",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime",
+ "sha-1 0.8.2",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -660,7 +775,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "hashbrown",
 ]
 
@@ -835,7 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -882,6 +997,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multipart"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error",
+ "rand 0.6.5",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,7 +1051,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
  "num-traits",
 ]
 
@@ -928,7 +1061,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -936,6 +1069,12 @@ name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -1059,6 +1198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,15 +1214,44 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1087,8 +1261,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1101,11 +1290,73 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1116,6 +1367,15 @@ checksum = "3300d224a86f356aaccb64cfc4c02118dc6df1a14c3270440eb8cc8e948ae825"
 dependencies = [
  "err-derive",
  "tokio",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1164,6 +1424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,7 +1458,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.7.0",
  "tokio",
  "tokio-rustls",
  "url",
@@ -1261,6 +1530,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -1335,6 +1610,18 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "serde_urlencoded"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
@@ -1374,15 +1661,27 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1458,6 +1757,20 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "rand 0.7.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1543,6 +1856,19 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project 0.4.27",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1679,10 +2005,19 @@ dependencies = [
  "httparse",
  "input_buffer",
  "log",
- "rand",
- "sha-1",
+ "rand 0.7.3",
+ "sha-1 0.9.2",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1755,6 +2090,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
+
+[[package]]
 name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +2138,34 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "pin-project 0.4.27",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.6.1",
+ "tokio",
+ "tokio-tungstenite",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ linemux = "0.1.2"
 rcon = "0.3.1"
 regex = "1.4.2"
 serde = { version = "1.0.117", features = ["derive"] }
+serde_json = "1.0"
 serenity = { version = "0.9.1" }
-tokio = { version = "0.2.22", features = ["time"] }
+tokio = { version = "0.2.22", features = ["sync", "time"] }
 tracing = "0.1.21"
 tracing-subscriber = "0.2.15"
+warp = "0.2"
 
 [profile.dev]
 # Let's speed up compilation and maybe reduce dev binary size a bunch.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Using a Discord webhook allows for much nicer messages to the Discord channel fr
 
 2. Copy the Webhook URL shown, and paste it in your Dolphin config, and enable using webhooks. Start Dolphin and that's it, you're done! :D
 
+### Listening for Remote Messages
+
+If you want to use this with a Minecraft server that is not on the same machine, you can enable the webserver listener in the config to listen for `POST` messages on the configured TCP port at the `/message` endpoint. For an easy way to send these messages, check out [dolphin-send](https://github.com/EbonJaeger/dolphin-send). If you wish to do this yourself, `dolphin-rs` expects the messages to have a body of content type `application/json` with this JSON schema:
+
+```json
+{
+  "name": "Username",
+  "content": "The message you want to send to the Discord channel.",
+  "source": "Player"
+}
+```
+
+`source` must be either `"Server"` or `"Player"`, and the name may be an empty string for non-player messages.
+
 ### Minecraft Message Template
 
 You can customize the message format for messages being sent to Minecraft (via the [tellraw command](https://minecraft.gamepedia.com/Commands/tellraw)). For a list of the various things you can use with the tellraw command, see [this wiki page](https://minecraft.gamepedia.com/Raw_JSON_text_format#Java_Edition). If you are unsure about what this does, the defaults match Vanilla Minecraft chat output.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct RootConfig {
     discord_config: DiscordConfig,
     minecraft_config: MinecraftConfig,
-    listener_config: ListenerConfig,
+    webserver_config: WebserverConfig,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -36,7 +36,7 @@ pub struct MinecraftConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-pub struct ListenerConfig {
+pub struct WebserverConfig {
     enabled: bool,
     port: u16,
 }
@@ -73,7 +73,7 @@ impl Default for RootConfig {
                     message_template: String::from("{\"color\":\"white\", \"text\":\"%content%\"}"),
                 },
             },
-            listener_config: ListenerConfig {
+            webserver_config: WebserverConfig {
                 enabled: false,
                 port: 25585,
             }
@@ -137,11 +137,11 @@ impl RootConfig {
         self.minecraft_config.templates.username_template.clone()
     }
 
-    pub fn use_listener(&self) -> bool {
-        self.listener_config.enabled
+    pub fn enable_webserver(&self) -> bool {
+        self.webserver_config.enabled
     }
 
-    pub fn get_listener_port(&self) -> u16 {
-        self.listener_config.port
+    pub fn get_webserver_port(&self) -> u16 {
+        self.webserver_config.port
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,9 +3,11 @@ extern crate confy;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct RootConfig {
     discord_config: DiscordConfig,
     minecraft_config: MinecraftConfig,
+    listener_config: ListenerConfig,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -31,6 +33,12 @@ pub struct MinecraftConfig {
     custom_death_keywords: Vec<String>,
     log_file_path: String,
     templates: TellrawTemplates,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ListenerConfig {
+    enabled: bool,
+    port: u16,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -65,6 +73,10 @@ impl Default for RootConfig {
                     message_template: String::from("{\"color\":\"white\", \"text\":\"%content%\"}"),
                 },
             },
+            listener_config: ListenerConfig {
+                enabled: false,
+                port: 25585,
+            }
         }
     }
 }
@@ -123,5 +135,13 @@ impl RootConfig {
 
     pub fn get_username_template(&self) -> String {
         self.minecraft_config.templates.username_template.clone()
+    }
+
+    pub fn use_listener(&self) -> bool {
+        self.listener_config.enabled
+    }
+
+    pub fn get_listener_port(&self) -> u16 {
+        self.listener_config.port
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,5 +1,6 @@
 use crate::config::RootConfig;
 use crate::errors::DolphinError;
+use crate::listener::{Listener, Webserver};
 use crate::minecraft::{MessageParser, MinecraftMessage, Source};
 use linemux::MuxedLines;
 use rcon::Connection;
@@ -260,34 +261,42 @@ impl EventHandler for Handler {
         }
 
         let guild_id = self.guild_id.load(Ordering::Relaxed);
-        let guild_id = GuildId(guild_id);
+        let guild_id = Arc::new(GuildId(guild_id));
         let log_path = &cfg.get_log_path();
 
         // Only do stuff if we're not already running
         if !self.is_watching.load(Ordering::Relaxed) {
-            info!("Using log file at '{}'", log_path);
+            if cfg.use_listener() {
+                tokio::spawn(async move {
+                    let listener =
+                        Webserver::new(Arc::clone(&ctx), Arc::clone(&cfg), Arc::clone(&guild_id));
+                    listener.listen().await;
+                });
+            } else {
+                info!("Using log file at '{}'", log_path);
 
-            let parser = MessageParser::new(cfg.get_death_keywords());
+                let parser = MessageParser::new(cfg.get_death_keywords());
 
-            // Create our log watcher
-            let mut log_watcher = MuxedLines::new().unwrap();
-            log_watcher
-                .add_file(&log_path)
-                .await
-                .expect("Unable to add the Minecraft log file to tail");
+                // Create our log watcher
+                let mut log_watcher = MuxedLines::new().unwrap();
+                log_watcher
+                    .add_file(&log_path)
+                    .await
+                    .expect("Unable to add the Minecraft log file to tail");
 
-            // Spawn a task to continuously tail the log file
-            tokio::spawn(async move {
-                info!("Started watching the Minecraft log file");
-                watch_log_file(
-                    Arc::clone(&ctx),
-                    Arc::clone(&cfg),
-                    guild_id,
-                    &mut log_watcher,
-                    parser,
-                )
-                .await;
-            });
+                // Spawn a task to continuously tail the log file
+                tokio::spawn(async move {
+                    info!("Started watching the Minecraft log file");
+                    watch_log_file(
+                        Arc::clone(&ctx),
+                        Arc::clone(&cfg),
+                        Arc::clone(&guild_id),
+                        &mut log_watcher,
+                        parser,
+                    )
+                    .await;
+                });
+            }
         }
 
         self.is_watching.swap(true, Ordering::Relaxed);
@@ -333,7 +342,7 @@ fn truncate_lines<'a>(lines: Split<'a, &'a str>) -> Vec<String> {
 async fn watch_log_file(
     ctx: Arc<Context>,
     cfg: Arc<RootConfig>,
-    guild_id: GuildId,
+    guild_id: Arc<GuildId>,
     log_watcher: &mut MuxedLines,
     parser: MessageParser,
 ) {
@@ -346,52 +355,69 @@ async fn watch_log_file(
             None => continue,
         };
 
-        // Get the correct name to use
-        let name = match message.source {
-            Source::Player => message.name.clone(),
-            Source::Server => ctx.cache.current_user().await.name,
-        };
+        send_to_discord(
+            Arc::clone(&ctx),
+            Arc::clone(&cfg),
+            Arc::clone(&guild_id),
+            message,
+        )
+        .await;
+    }
+}
 
-        let mut content = message.content.clone();
-        if cfg.mentions_allowed() {
-            content = replace_mentions(Arc::clone(&ctx), guild_id, content).await;
+pub async fn send_to_discord(
+    ctx: Arc<Context>,
+    cfg: Arc<RootConfig>,
+    guild_id: Arc<GuildId>,
+    message: MinecraftMessage,
+) -> Result<(), DolphinError> {
+    // Get the correct name to use
+    let name = match message.source {
+        Source::Player => message.name.clone(),
+        Source::Server => ctx.cache.current_user().await.name,
+    };
+
+    let mut content = message.content.clone();
+    if cfg.mentions_allowed() {
+        content = replace_mentions(Arc::clone(&ctx), guild_id, content).await;
+    }
+
+    let message = MinecraftMessage {
+        name: name.clone(),
+        content,
+        source: message.source,
+    };
+
+    // Check if we should use a webhook to post the message
+    if cfg.webhook_enabled() {
+        let url = &cfg.webhook_url();
+
+        if let Err(e) = post_to_webhook(Arc::clone(&ctx), message, url).await {
+            return Err(e);
         }
-
-        let message = MinecraftMessage {
-            name: name.clone(),
-            content,
-            source: message.source,
+    } else {
+        // Send the message to the channel
+        let final_msg = match message.source {
+            Source::Player => format!("**{}**: {}", message.name, message.content),
+            Source::Server => message.content,
         };
 
-        // Check if we should use a webhook to post the message
-        if cfg.webhook_enabled() {
-            let url = &cfg.webhook_url();
-
-            if let Err(e) = post_to_webhook(Arc::clone(&ctx), message, url).await {
-                error!("Error posting to webhook: {}", e);
-            }
-        } else {
-            // Send the message to the channel
-            let final_msg = match message.source {
-                Source::Player => format!("**{}**: {}", message.name, message.content),
-                Source::Server => message.content,
-            };
-
-            if let Err(e) = ChannelId(cfg.get_channel_id()).say(&ctx, final_msg).await {
-                error!("Error sending a message to Discord: {}", e);
-            }
+        if let Err(e) = ChannelId(cfg.get_channel_id()).say(&ctx, final_msg).await {
+            return Err(DolphinError::Discord(e));
         }
     }
+
+    Ok(())
 }
 
 ///
 /// Looks for instances of user mentions in a message and attempts
 /// to replace that text with an actual Discord @mention.
 ///
-async fn replace_mentions(ctx: Arc<Context>, guild_id: GuildId, message: String) -> String {
+async fn replace_mentions(ctx: Arc<Context>, guild_id: Arc<GuildId>, message: String) -> String {
     let mut ret = message.clone();
 
-    if let Some(guild) = ctx.cache.guild(guild_id).await {
+    if let Some(guild) = ctx.cache.guild(*guild_id).await {
         // Try to match names using the full name and optionally
         // the user descriptor. This works for names that have
         // spaces in them, and really probably anything else.

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -266,9 +266,9 @@ impl EventHandler for Handler {
 
         // Only do stuff if we're not already running
         if !self.is_watching.load(Ordering::Relaxed) {
-            if cfg.use_listener() {
+            if cfg.enable_webserver() {
                 let (tx, mut rx) = mpsc::channel(100);
-                let port = cfg.get_listener_port();
+                let port = cfg.get_webserver_port();
                 tokio::spawn(async move {
                     let listener = Webserver::new(port);
                     listener.listen(tx).await;
@@ -390,7 +390,7 @@ async fn watch_log_file(
     }
 }
 
-pub async fn send_to_discord(
+async fn send_to_discord(
     ctx: Arc<Context>,
     cfg: Arc<RootConfig>,
     guild_id: Arc<GuildId>,

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,0 +1,70 @@
+use crate::config::RootConfig;
+use crate::discord::send_to_discord;
+use crate::minecraft::MinecraftMessage;
+use serenity::{async_trait, model::id::GuildId, prelude::Context};
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+use tracing::debug;
+use warp::Filter;
+
+#[async_trait]
+pub trait Listener {
+    async fn listen(&self);
+}
+
+pub struct Webserver {
+    ctx: Arc<Context>,
+    cfg: Arc<RootConfig>,
+    guild_id: Arc<GuildId>,
+    // tx: Sender<MinecraftMessage>,
+}
+
+impl Webserver {
+    pub fn new(
+        ctx: Arc<Context>,
+        cfg: Arc<RootConfig>,
+        guild_id: Arc<GuildId>,
+        // tx: Sender<MinecraftMessage>,
+    ) -> Self {
+        Webserver {
+            ctx,
+            cfg,
+            guild_id,
+            // tx,
+        }
+    }
+}
+
+#[async_trait]
+impl Listener for Webserver {
+    async fn listen(&self) {
+        // let txc = tx.clone();
+        // POST /message/:msg
+        let messages = warp::post()
+            .and(warp::path("message"))
+            .and(warp::body::content_length_limit(1024 * 16))
+            .and(warp::body::json())
+            .map(|message: MinecraftMessage| {
+                debug!(
+                    "dolphin:warp: received a message from a Minecraft instance: {:?}",
+                    message
+                );
+
+                warp::reply()
+            });
+        // .and_then(move |msg: MinecraftMessage| async move {
+        //     debug!(
+        //         "dolphin:warp: received a message from a Minecraft instance: {:?}",
+        //         msg
+        //     );
+        //     match txc.send(msg).await {
+        //         Ok(()) => Ok(format!("post success")),
+        //         Err(e) => Err(warp::reject::not_found()),
+        //     }
+        // });
+
+        warp::serve(messages)
+            .run(([127, 0, 0, 1], self.cfg.get_listener_port()))
+            .await
+    }
+}

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,70 +1,48 @@
-use crate::config::RootConfig;
-use crate::discord::send_to_discord;
 use crate::minecraft::MinecraftMessage;
-use serenity::{async_trait, model::id::GuildId, prelude::Context};
-use std::sync::Arc;
+use serenity::async_trait;
 use tokio::sync::mpsc::Sender;
-use tracing::debug;
 use warp::Filter;
 
 #[async_trait]
 pub trait Listener {
-    async fn listen(&self);
+    async fn listen(&self, tx: Sender<MinecraftMessage>);
 }
 
 pub struct Webserver {
-    ctx: Arc<Context>,
-    cfg: Arc<RootConfig>,
-    guild_id: Arc<GuildId>,
-    // tx: Sender<MinecraftMessage>,
+    port: u16,
 }
 
 impl Webserver {
-    pub fn new(
-        ctx: Arc<Context>,
-        cfg: Arc<RootConfig>,
-        guild_id: Arc<GuildId>,
-        // tx: Sender<MinecraftMessage>,
-    ) -> Self {
-        Webserver {
-            ctx,
-            cfg,
-            guild_id,
-            // tx,
-        }
+    pub fn new(port: u16) -> Self {
+        Webserver { port }
     }
 }
 
 #[async_trait]
 impl Listener for Webserver {
-    async fn listen(&self) {
-        // let txc = tx.clone();
+    async fn listen(&self, tx: Sender<MinecraftMessage>) {
         // POST /message/:msg
         let messages = warp::post()
             .and(warp::path("message"))
             .and(warp::body::content_length_limit(1024 * 16))
             .and(warp::body::json())
-            .map(|message: MinecraftMessage| {
-                debug!(
-                    "dolphin:warp: received a message from a Minecraft instance: {:?}",
-                    message
-                );
-
-                warp::reply()
+            // .map(|message: MinecraftMessage| {
+            //     debug!(
+            //         "dolphin:warp: received a message from a Minecraft instance: {:?}",
+            //         message
+            //     );
+            //     warp::reply()
+            // });
+            .and_then(move |msg: MinecraftMessage| {
+                let mut txc = tx.clone();
+                async move {
+                    match txc.send(msg).await {
+                        Ok(()) => Ok(format!("post success")),
+                        Err(_) => Err(warp::reject::not_found()),
+                    }
+                }
             });
-        // .and_then(move |msg: MinecraftMessage| async move {
-        //     debug!(
-        //         "dolphin:warp: received a message from a Minecraft instance: {:?}",
-        //         msg
-        //     );
-        //     match txc.send(msg).await {
-        //         Ok(()) => Ok(format!("post success")),
-        //         Err(e) => Err(warp::reject::not_found()),
-        //     }
-        // });
 
-        warp::serve(messages)
-            .run(([127, 0, 0, 1], self.cfg.get_listener_port()))
-            .await
+        warp::serve(messages).run(([127, 0, 0, 1], self.port)).await
     }
 }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -26,19 +26,12 @@ impl Listener for Webserver {
             .and(warp::path("message"))
             .and(warp::body::content_length_limit(1024 * 16))
             .and(warp::body::json())
-            // .map(|message: MinecraftMessage| {
-            //     debug!(
-            //         "dolphin:warp: received a message from a Minecraft instance: {:?}",
-            //         message
-            //     );
-            //     warp::reply()
-            // });
             .and_then(move |msg: MinecraftMessage| {
                 let mut txc = tx.clone();
                 async move {
                     match txc.send(msg).await {
-                        Ok(()) => Ok(format!("post success")),
-                        Err(_) => Err(warp::reject::not_found()),
+                        Ok(()) => Ok(""),
+                        Err(_) => Err(warp::reject::reject()),
                     }
                 }
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod commands;
 mod config;
 mod discord;
 mod errors;
+mod listener;
 mod minecraft;
 
 #[macro_use]

--- a/src/minecraft.rs
+++ b/src/minecraft.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+
 #[derive(Clone)]
 pub struct MessageParser {
     death_keywords: Vec<String>,
@@ -170,13 +172,13 @@ fn trim_prefix(line: &str) -> Option<&str> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub enum Source {
     Player,
     Server,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct MinecraftMessage {
     pub name: String,
     pub content: String,


### PR DESCRIPTION
Just what it says on the tin: This PR opens up the ability to listen for JSON messages `POST`'ed to an endpoint for them to be sent to Discord. This opens up the possibility of using one bot for multiple Minecraft servers. A bunch of works would have to be done first for that to be a reality, though.

Right now, this expects messages to already have been parsed and filtered out. This will probably be eased after further decoupling of the listener portion from the rest of the bot. The eventual goal is to have a single pipeline for messages that could come from multiple sources.